### PR TITLE
Implement move parser

### DIFF
--- a/app/src/main/java/chess/classes/Move.java
+++ b/app/src/main/java/chess/classes/Move.java
@@ -1,6 +1,8 @@
 package chess.classes;
 
 import java.text.ParseException;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Represents the algebraic notation of a move.
@@ -28,13 +30,21 @@ public final class Move {
   private boolean isQueenSideCastle;
   private boolean isKingSideCastle;
 
+  /** All possible characters in algebraic notation. */
+  private static final Set<Character> validCharacters =
+      // file     +  ranks     + pieces  + other
+      ("abcdefgh" + "12345678" + "KQBNR" + "x0-+#")
+          .chars()
+          .mapToObj(e -> (char) e)
+          .collect(Collectors.toSet());
+
   /** Default constructor is private, use Move.parse(String notation) to generate a move. */
   private Move() {}
 
   /**
    * Parses a Move from an algebraic notation string.
    *
-   * @param notation the algebraic notation for the given move.
+   * @param notationIn the algebraic notation for the given move.
    * @return a Move object representing the notation.
    * @throws IllegalArgumentException if notation is null.
    * @throws ParseException if the given notation cannot be parsed
@@ -43,6 +53,12 @@ public final class Move {
     String notation = notationIn;
     if (notation == null || notation.isEmpty()) {
       throw new IllegalArgumentException("Notation cannot be null or empty.");
+    }
+
+    // Ensure all characters in the notation are valid.
+    if (!Move.validCharacters.containsAll(
+        notation.chars().mapToObj(e -> (char) e).collect(Collectors.toSet()))) {
+      throw new ParseException(notation, 0);
     }
     Move m = new Move();
     // Special cases

--- a/app/src/main/java/chess/classes/Move.java
+++ b/app/src/main/java/chess/classes/Move.java
@@ -6,10 +6,12 @@ import java.text.ParseException;
  * Represents the algebraic notation of a move.
  *
  * <p>https://en.wikipedia.org/wiki/Algebraic_notation_(chess)
+ *
+ * @implNote Consider turning Parse method into a MoveFactory
  */
 public final class Move {
   // Consider changing rank, file, and movedPiece to Enums.
-  private int rank;
+  private char rank;
   private char file;
   private char movedPiece;
 
@@ -22,6 +24,10 @@ public final class Move {
   private char fromRank;
   private char pawnPromotedTo;
 
+  // Castels
+  private boolean isQueenSideCastle;
+  private boolean isKingSideCastle;
+
   /** Default constructor is private, use Move.parse(String notation) to generate a move. */
   private Move() {}
 
@@ -33,12 +39,145 @@ public final class Move {
    * @throws IllegalArgumentException if notation is null.
    * @throws ParseException if the given notation cannot be parsed
    */
-  public static Move parse(final String notation) {
-    return new Move();
+  public static Move parse(final String notationIn) throws ParseException {
+    String notation = notationIn;
+    if (notation == null || notation.isEmpty()) {
+      throw new IllegalArgumentException("Notation cannot be null or empty.");
+    }
+    Move m = new Move();
+    // Special cases
+    if (notation.equals("0-0-0")) {
+      m.isQueenSideCastle = true;
+      return m;
+    }
+    if (notation.equals("0-0")) {
+      m.isKingSideCastle = true;
+      return m;
+    }
+
+    // Get Check / checkmate from end of string
+    if ('+' == notation.charAt(notation.length() - 1)) {
+      m.isCheck = true;
+      notation = notation.substring(0, notation.length() - 1);
+    }
+    if ('#' == notation.charAt(notation.length() - 1)) {
+      m.isCheckmate = true;
+      notation = notation.substring(0, notation.length() - 1);
+    }
+
+    // Check if a pawn is promoted
+    if (Character.isUpperCase(notation.charAt(notation.length() - 1))) {
+      m.pawnPromotedTo = notation.charAt(notation.length() - 1);
+      notation = notation.substring(0, notation.length() - 1);
+    }
+
+    // Get Moved piece - If the first letter is not capitalized a pawn moved.
+    if (Character.isUpperCase(notation.charAt(0))) {
+      m.movedPiece = notation.charAt(0);
+      notation = notation.substring(1);
+    }
+
+    // Check if the move is a capture
+    if (notation.indexOf('x') != -1) {
+      m.isCapture = true;
+      notation = notation.replace("x", "");
+    }
+
+    // Get Rank / File moved to
+    m.rank = notation.charAt(notation.length() - 1);
+    m.file = notation.charAt(notation.length() - 2);
+    notation = notation.substring(0, notation.length() - 2);
+
+    // Check if the to rank/file is notated.
+    if (notation.length() == 0) {
+      return m;
+    }
+
+    // Get from file
+    if (Character.isLetter(notation.charAt(0))) {
+      m.fromFile = notation.charAt(0);
+      notation = notation.substring(1);
+    }
+    if (notation.length() == 0) {
+      return m;
+    }
+
+    if (Character.isDigit(notation.charAt(0))) {
+      m.fromRank = notation.charAt(0);
+      notation = notation.substring(1);
+    }
+    if (notation.length() == 0) {
+      return m;
+    }
+
+    if (notation.length() != 0) {
+      throw new ParseException(notation, 0);
+    }
+
+    return m;
   }
 
   /** Returns the algebraic notation for a given move. */
   public String toString() {
-    return "";
+    if (this.isKingSideCastle) {
+      return "0-0";
+    }
+    if (this.isQueenSideCastle) {
+      return "0-0-0";
+    }
+    return ""
+        + (this.movedPiece == '\u0000' ? "" : this.movedPiece)
+        + (this.fromFile == '\u0000' ? "" : this.fromFile)
+        + (this.fromRank == '\u0000' ? "" : this.fromRank)
+        + (this.isCapture ? "x" : "")
+        + this.file
+        + this.rank
+        + (this.pawnPromotedTo == '\u0000' ? "" : this.pawnPromotedTo)
+        + (this.isCheck ? "+" : "")
+        + (this.isCheckmate ? "#" : "");
+  }
+
+  public int getRank() {
+    return rank;
+  }
+
+  public char getFile() {
+    return file;
+  }
+
+  public char getMovedPiece() {
+    return movedPiece;
+  }
+
+  public boolean isCapture() {
+    return isCapture;
+  }
+
+  public boolean isCheck() {
+    return isCheck;
+  }
+
+  public boolean isCheckmate() {
+    return isCheckmate;
+  }
+
+  public char getFromFile() {
+    return fromFile;
+  }
+
+  public char getFromRank() {
+    return fromRank;
+  }
+
+  public char getPawnPromotedTo() {
+    return pawnPromotedTo;
+  }
+
+  public boolean isQueenSideCastle() {
+    return isQueenSideCastle;
+  }
+
+  public boolean isKingSideCastle() {
+    return isKingSideCastle;
   }
 }

--- a/app/src/test/java/chess/classes/MoveTest.java
+++ b/app/src/test/java/chess/classes/MoveTest.java
@@ -1,8 +1,12 @@
 package chess.classes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
+import java.text.ParseException;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class MoveTest {
@@ -11,10 +15,22 @@ class MoveTest {
   @ValueSource(
       strings = {
         "Bxe5", "Be5", "Kf3", "exd5", "0-0-0", "0-0", "Rdf8", "R1a3", "Qh4e1", "Qh4xe1", "e8Q",
-        "a1Q", "Be5+", "Be5#"
+        "a1Q", "Be5+", "Be5#", "e8Q#"
       })
-  void testOutputFromToStringMatchesParsedInput(final String input) {
+  void testOutputFromToStringMatchesParsedInput(final String input) throws ParseException {
     final Move m = Move.parse(input);
     assertEquals(input, m.toString());
+  }
+
+  @ParameterizedTest(name = "Test parse throws parse Error on invalid input -- {0}")
+  @ValueSource(strings = {"O-O-O", "O-0", "NxT9", "aaaaa", "A", "Just some random string"})
+  void testParseThrowsWhenPassedInvalidInput(final String input) throws ParseException {
+    assertThrowsExactly(ParseException.class, () -> Move.parse(input));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void testParseThrowsWhenNotationIsNullOrEmpty(final String input) throws ParseException {
+    assertThrows(IllegalArgumentException.class, () -> Move.parse(input));
   }
 }


### PR DESCRIPTION
Implemented a parser for [Algebraic Notation](https://en.wikipedia.org/wiki/Algebraic_notation_(chess)). 

This parser can be used to take user input (via CLI for example) and transform it into a more usable object.

It might be worth refactoring to utilize a createtional pattern (probably the Builder).  
As well as creating two special case sub-classes for castling (king-side & queen-side)