### PR TITLE
Added more pawn isValidMove Fixes

### DIFF
--- a/app/src/main/java/core/classes/Pawn.java
+++ b/app/src/main/java/core/classes/Pawn.java
@@ -60,6 +60,9 @@ public class Pawn extends BasePiece {
   }
 
   private boolean isValidTwoSquare(Board b, Move m) {
+    if (m.isCapture()) {
+      return false;
+    }
     int rankDelta = m.getRank() - m.getFromRank();
     int rankDir = Math.abs(rankDelta) / rankDelta;
     if (Math.abs(rankDelta) != 2) {
@@ -81,6 +84,11 @@ public class Pawn extends BasePiece {
 
   private boolean isValidEnPassant(Board b, Move m) {
     char expectedRank = this.color.equals(Color.WHITE) ? '5' : '4';
+    char moveToRank = this.color.equals(Color.WHITE) ? '6' : '3';
+
+    if (m.getRank() != moveToRank) {
+      return false;
+    }
 
     // toSquare must be empty and captured piece must exist & be a different
     // color & a pawn

--- a/app/src/test/java/core/classes/PawnTest.java
+++ b/app/src/test/java/core/classes/PawnTest.java
@@ -63,6 +63,9 @@ public class PawnTest {
     b.move(Move.parse("d7d5"));
     // Next move is en-passant
     assertFalse(p.isValidMove(b, Move.parse("e5xd7")));
+    assertFalse(p.isValidMove(b, Move.parse("e5xd4")));
+    assertFalse(p.isValidMove(b, Move.parse("e5xd3")));
+    assertFalse(p.isValidMove(b, Move.parse("e5xd5")));
   }
 
   @ParameterizedTest(name = "isValidMove (valid) {0}")

--- a/app/src/test/java/core/classes/PawnTest.java
+++ b/app/src/test/java/core/classes/PawnTest.java
@@ -51,6 +51,20 @@ public class PawnTest {
     assertTrue(p.isValidMove(b, Move.parse("e5xd6")));
   }
 
+    @Test
+  void testEnPassantMovesToCorrectRank() throws ParseException {
+    Board b = Board.createEmtpyBoard();
+    Pawn p = new Pawn(Color.WHITE);
+    b.setSquare('d', '7', new Pawn(Color.BLACK));
+    // Capturing pawn has advanced 3 ranks (2 -> 5)
+    b.setSquare('e', '5', p);
+    // Captured pawn advanced two squares in one
+    // move, landing next to the capturing pawn
+    b.move(Move.parse("d7d5"));
+    // Next move is en-passant
+    assertFalse(p.isValidMove(b, Move.parse("e5xd7")));
+  }
+
   @ParameterizedTest(name = "isValidMove (valid) {0}")
   @ValueSource(strings = {"d2d4", "a2a3", "a2xb3", "c4c5"})
   void testIsValidMove(String notationIn) throws ParseException {
@@ -63,11 +77,12 @@ public class PawnTest {
   @ParameterizedTest(name = "isValidMove (invalid) {0}")
   @ValueSource(
       strings = {
-        "a4a2", "a3a5", "a4a3", "c3xe5", "a2g5", "a2xg5", "a7g5", "a2b3", "a2c3", "a2c4", "a2f2"
+        "a4a2", "a3a5", "a4a3", "c3xe5", "a2g5", "a2xg5", "a7g5", "a2b3", "a2c3", "a2c4", "a2f2", "g2xh4"
       })
   void testIsInValidMove(String notationIn) throws ParseException {
     Board b = Board.createEmtpyBoard();
     b.setSquare('e', '5', new Pawn(Color.BLACK));
+    b.setSquare('h', '4', new Pawn(Color.BLACK));
     Pawn p = new Pawn(Color.WHITE);
     assertFalse(p.isValidMove(b, Move.parse(notationIn)));
   }

--- a/app/src/test/java/core/classes/PawnTest.java
+++ b/app/src/test/java/core/classes/PawnTest.java
@@ -51,7 +51,7 @@ public class PawnTest {
     assertTrue(p.isValidMove(b, Move.parse("e5xd6")));
   }
 
-    @Test
+  @Test
   void testEnPassantMovesToCorrectRank() throws ParseException {
     Board b = Board.createEmtpyBoard();
     Pawn p = new Pawn(Color.WHITE);
@@ -80,7 +80,8 @@ public class PawnTest {
   @ParameterizedTest(name = "isValidMove (invalid) {0}")
   @ValueSource(
       strings = {
-        "a4a2", "a3a5", "a4a3", "c3xe5", "a2g5", "a2xg5", "a7g5", "a2b3", "a2c3", "a2c4", "a2f2", "g2xh4"
+        "a4a2", "a3a5", "a4a3", "c3xe5", "a2g5", "a2xg5", "a7g5", "a2b3", "a2c3", "a2c4", "a2f2",
+        "g2xh4"
       })
   void testIsInValidMove(String notationIn) throws ParseException {
     Board b = Board.createEmtpyBoard();


### PR DESCRIPTION
Fixed the following issues reported by @Malcolm-Shepherd 

## On EnPassant, the pawn capturing can move to any open space in the column

![image](https://user-images.githubusercontent.com/17833726/171055538-1f5785bf-b2ef-4e7f-b66e-2bd19313f5d1.png)

## On spawn, pawns are able to capture 2 rows forward and one column to the side

![image](https://user-images.githubusercontent.com/17833726/171055547-bf374169-f8ff-438a-90f2-9750609844b3.png)
